### PR TITLE
Add support for importing private keys to create credential

### DIFF
--- a/credential.go
+++ b/credential.go
@@ -9,16 +9,30 @@ type Credential struct {
 }
 
 func NewCredential(keyType KeyType) Credential {
-	cred := Credential{}
-	cred.ID = randomBytes(32)
+
+	key := Key{}
 	if keyType == KeyTypeEC2 {
-		cred.Key = Key{Type: keyType, SigningKey: newEC2SigningKey()}
+		key = Key{Type: keyType, SigningKey: newEC2SigningKey()}
 	} else if keyType == KeyTypeRSA {
-		cred.Key = Key{Type: keyType, SigningKey: newRSASigningKey()}
+		key = Key{Type: keyType, SigningKey: newRSASigningKey()}
 	} else {
 		panic("Invalid credential key type")
 	}
+
 	return cred
+}
+
+func NewCredentialWithImportedKey(keyType KeyType, PKCS8PrivateKey []byte) Credential {
+	key := Key{}
+	cred.ID = randomBytes(32)
+	if keyType == KeyTypeEC2 {
+		key = Key{Type: keyType, SigningKey: importPKCS8EC2SigningKey(PKCS8PrivateKey)}
+	} else if keyType == KeyTypeRSA {
+		key = Key{Type: keyType, SigningKey: importPKCS8RSASigningKey(PKCS8PrivateKey)}
+	} else {
+		panic("Invalid credential key type")
+	}
+	return createCredential(keyType, ket)
 }
 
 func (c *Credential) IsExcludedForAttestation(options AttestationOptions) bool {
@@ -39,4 +53,11 @@ func (c *Credential) IsAllowedForAssertion(options AssertionOptions) bool {
 		}
 	}
 	return false
+}
+
+func createCredential(key Key) Credential {
+	cred := Credential{}
+	cred.ID = randomBytes(32)
+	cred.Key = key
+	return cred
 }


### PR DESCRIPTION
## Description
Hi there, I just extended your code to import private keys (in PKCS8 ie. pem format) to create credential object. Please feel free to make changes if you see fit.

Thanks for the work by the way, this is a brilliant and useful project 😄 
