### PR TITLE
Add Support for Export and Import of Credentials

### DIFF
--- a/ec2.go
+++ b/ec2.go
@@ -58,6 +58,10 @@ func (k *ec2SigningKey) Sign(digest []byte) (signature []byte, err error) {
 	return k.Key.Sign(rand.Reader, digest, nil)
 }
 
+func (k *ec2SigningKey) ExportToPKCS8Key() (PKCS8Key []byte, err error) {
+	return x509.MarshalPKCS8PrivateKey(k.Key)
+}
+
 type ec2KeyInfo struct {
 	Type      int64  `cbor:"1,keyasint"`
 	Algorithm int64  `cbor:"3,keyasint"`

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/webauthn v0.6.1 h1:Vh5Kfuul05zCffJN8PGk1aqeTIw14syrorcwDMeVlN0=
 github.com/fxamacker/webauthn v0.6.1/go.mod h1:dOZK7yO04AnMvkmC+HLP6YO32doyu+fRPQlY0wD4Lb0=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=

--- a/key.go
+++ b/key.go
@@ -15,6 +15,7 @@ const (
 type SigningKey interface {
 	KeyData() []byte
 	Sign(digest []byte) (signature []byte, err error)
+	ExportToPKCS8Key() (PKCS8Key []byte, err error)
 }
 
 func (keyType KeyType) newKey() Key {
@@ -23,17 +24,6 @@ func (keyType KeyType) newKey() Key {
 		return Key{Type: keyType, SigningKey: newEC2SigningKey()}
 	case KeyTypeRSA:
 		return Key{Type: keyType, SigningKey: newRSASigningKey()}
-	default:
-		panic("invalid key type")
-	}
-}
-
-func (keyType KeyType) importKey(keyBytes []byte) Key {
-	switch keyType {
-	case KeyTypeEC2:
-		return Key{Type: keyType, SigningKey: importEC2SigningKey(keyBytes)}
-	case KeyTypeRSA:
-		return Key{Type: keyType, SigningKey: importRSASigningKey(keyBytes)}
 	default:
 		panic("invalid key type")
 	}

--- a/portable_credential.go
+++ b/portable_credential.go
@@ -1,0 +1,27 @@
+package virtualwebauthn
+
+type PortableCredential struct {
+	ID       []byte  `json:"id"`
+	PKCS8Key []byte  `json:"key"`
+	KeyType  KeyType `json:"keyType,omitempty"`
+	Counter  uint32  `json:"counter,omitempty"`
+}
+
+func (p *PortableCredential) ToCredential() Credential {
+	key := Key{}
+	if p.KeyType == KeyTypeEC2 {
+		key = Key{Type: p.KeyType, SigningKey: importEC2SigningKey(p.PKCS8Key)}
+	} else if p.KeyType == KeyTypeRSA {
+		key = Key{Type: p.KeyType, SigningKey: importRSASigningKey(p.PKCS8Key)}
+	} else {
+		panic("Invalid credential key type")
+	}
+
+	cred := Credential{
+		ID:      p.ID,
+		Key:     key,
+		Counter: p.Counter,
+	}
+
+	return cred
+}

--- a/rsa.go
+++ b/rsa.go
@@ -57,6 +57,10 @@ func (k *rsaSigningKey) Sign(digest []byte) (signature []byte, err error) {
 	return rsa.SignPKCS1v15(rand.Reader, k.Key, crypto.SHA256, digest)
 }
 
+func (k *rsaSigningKey) ExportToPKCS8Key() (PKCS8Key []byte, err error) {
+	return x509.MarshalPKCS8PrivateKey(k.Key)
+}
+
 type rasKeyInfo struct {
 	Type      int64  `cbor:"1,keyasint"`
 	Algorithm int64  `cbor:"3,keyasint"`

--- a/test/export_test.go
+++ b/test/export_test.go
@@ -1,0 +1,101 @@
+package test
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"testing"
+
+	"github.com/descope/virtualwebauthn"
+	_ "github.com/fxamacker/webauthn/packed"
+	"github.com/stretchr/testify/require"
+)
+
+const secret = "My Super Secret!!!"
+
+func TestExportedEC2Key(t *testing.T) {
+
+	portableCred := createEC2PortableCredential(t)
+
+	cred := portableCred.ToCredential()
+
+	exportedPortableCred := cred.ExportToPortableCredential()
+
+	require.Equal(t, portableCred, exportedPortableCred)
+}
+
+func TestExportedRSAKey(t *testing.T) {
+
+	portableCred := createRSAPortableCredential(t)
+
+	cred := portableCred.ToCredential()
+
+	exportedPortableCred := cred.ExportToPortableCredential()
+
+	require.Equal(t, portableCred, exportedPortableCred)
+}
+
+func TestExportedGeneratedEC2Key(t *testing.T) {
+
+	cred := virtualwebauthn.NewCredential(virtualwebauthn.KeyTypeEC2)
+
+	hasher := crypto.SHA256.New()
+	hasher.Write([]byte(secret))
+	digest := hasher.Sum(nil)
+
+	sign, err := cred.Key.SigningKey.Sign(digest)
+	require.NoError(t, err)
+
+	exportedPortableCred := cred.ExportToPortableCredential()
+
+	key := parseEc2Key(t, exportedPortableCred)
+
+	publicKey, ok := key.Public().(*ecdsa.PublicKey)
+	require.True(t, ok)
+
+	success := ecdsa.VerifyASN1(publicKey, digest, sign)
+	require.True(t, success)
+
+}
+
+func TestExportedGeneratedRSAKey(t *testing.T) {
+	cred := virtualwebauthn.NewCredential(virtualwebauthn.KeyTypeRSA)
+
+	hasher := crypto.SHA256.New()
+	hasher.Write([]byte(secret))
+	digest := hasher.Sum(nil)
+
+	sign, err := cred.Key.SigningKey.Sign(digest)
+	require.NoError(t, err)
+
+	exportedPortableCred := cred.ExportToPortableCredential()
+
+	key := parseRsaKey(t, exportedPortableCred)
+
+	publicKey, ok := key.Public().(*rsa.PublicKey)
+	require.True(t, ok)
+
+	err = rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, digest, sign)
+	require.Nil(t, err)
+}
+
+func parseEc2Key(t *testing.T, cred virtualwebauthn.PortableCredential) *ecdsa.PrivateKey {
+	parsed, err := x509.ParsePKCS8PrivateKey(cred.PKCS8Key)
+	require.NoError(t, err)
+
+	key, ok := parsed.(*ecdsa.PrivateKey)
+	require.True(t, ok)
+
+	return key
+}
+
+func parseRsaKey(t *testing.T, cred virtualwebauthn.PortableCredential) *rsa.PrivateKey {
+	parsed, err := x509.ParsePKCS8PrivateKey(cred.PKCS8Key)
+	require.NoError(t, err)
+
+	key, ok := parsed.(*rsa.PrivateKey)
+	require.True(t, ok)
+
+	return key
+}

--- a/test/import_test.go
+++ b/test/import_test.go
@@ -47,21 +47,45 @@ const rsaKey = `
 	1eaa3c0638d115432c714c2b3b33c8f9f028`
 
 func TestImportedEC2Key(t *testing.T) {
-	keyString := regexp.MustCompile(`\s+`).ReplaceAllString(ec2Key, "")
-	keyBytes, err := hex.DecodeString(keyString)
-	require.NoError(t, err)
 
-	cred := virtualwebauthn.NewCredentialWithImportedKey(virtualwebauthn.KeyTypeEC2, keyBytes)
-	testImportedCredential(t, cred)
+	portableCred := createEC2PortableCredential(t)
+	testImportedCredential(t, portableCred.ToCredential())
 }
 
 func TestImportedRSAKey(t *testing.T) {
+	portableCred := createRSAPortableCredential(t)
+	testImportedCredential(t, portableCred.ToCredential())
+}
+
+func createRSAPortableCredential(t *testing.T) virtualwebauthn.PortableCredential {
 	keyString := regexp.MustCompile(`\s+`).ReplaceAllString(rsaKey, "")
 	keyBytes, err := hex.DecodeString(keyString)
 	require.NoError(t, err)
 
-	cred := virtualwebauthn.NewCredentialWithImportedKey(virtualwebauthn.KeyTypeRSA, keyBytes)
-	testImportedCredential(t, cred)
+	portableCred := virtualwebauthn.PortableCredential{
+		ID:       []byte("My Credential ID"),
+		PKCS8Key: keyBytes,
+		KeyType:  virtualwebauthn.KeyTypeRSA,
+		Counter:  0,
+	}
+
+	return portableCred
+}
+
+func createEC2PortableCredential(t *testing.T) virtualwebauthn.PortableCredential {
+	keyString := regexp.MustCompile(`\s+`).ReplaceAllString(ec2Key, "")
+	keyBytes, err := hex.DecodeString(keyString)
+	require.NoError(t, err)
+
+	portableCred := virtualwebauthn.PortableCredential{
+		ID:       []byte("My Credential ID"),
+		PKCS8Key: keyBytes,
+		KeyType:  virtualwebauthn.KeyTypeEC2,
+		Counter:  0,
+	}
+
+	return portableCred
+
 }
 
 func testImportedCredential(t *testing.T, cred virtualwebauthn.Credential) {


### PR DESCRIPTION
* Created PortableCredential struct
* func ToCredential() to create Credential from PortableCredential
* func ExportToPortableCredential() to create PortalCredential from Credential

* Updated import_test
* Added export_test

## Description
This is an improvement to my earlier PR, this is allows for Import and Exporting the credential. I have updated existing tests and created ones for export cases. I am open to any design changes/suggestions

## Must
- [X ] Tests
- [ ] Documentation (if applicable)
