### PR TITLE
add BS and BE flag support

### DIFF
--- a/assertion.go
+++ b/assertion.go
@@ -64,7 +64,14 @@ func CreateAssertionResponse(rp RelyingParty, auth Authenticator, cred Credentia
 	clientDataJSONEncoded := base64.RawURLEncoding.EncodeToString(clientDataJSON)
 
 	rpIDHash := sha256.Sum256([]byte(rp.ID))
-	flags := authenticatorDataFlags(!auth.Options.UserNotPresent, !auth.Options.UserNotVerified, false, false)
+	flags := authenticatorDataFlags(
+		!auth.Options.UserNotPresent,
+		!auth.Options.UserNotVerified,
+		auth.Options.BackupEligible,
+		auth.Options.BackupState,
+		false,
+		false,
+	)
 
 	authData := []byte{}
 	authData = append(authData, rpIDHash[:]...)

--- a/attestation.go
+++ b/attestation.go
@@ -86,7 +86,14 @@ func CreateAttestationResponse(rp RelyingParty, auth Authenticator, cred Credent
 	credData = append(credData, publicKeyData...)
 
 	rpIDHash := sha256.Sum256([]byte(rp.ID))
-	flags := authenticatorDataFlags(!auth.Options.UserNotPresent, !auth.Options.UserNotVerified, true, false)
+	flags := authenticatorDataFlags(
+		!auth.Options.UserNotPresent,
+		!auth.Options.UserNotVerified,
+		auth.Options.BackupEligible,
+		auth.Options.BackupState,
+		true,
+		false,
+	)
 
 	authData := []byte{}
 	authData = append(authData, rpIDHash[:]...)

--- a/authenticator.go
+++ b/authenticator.go
@@ -4,6 +4,8 @@ type AuthenticatorOptions struct {
 	UserHandle      []byte
 	UserNotPresent  bool
 	UserNotVerified bool
+	BackupEligible  bool
+	BackupState     bool
 }
 
 type Authenticator struct {

--- a/utils.go
+++ b/utils.go
@@ -42,7 +42,7 @@ func bigEndianBytes[T interface{ int | uint32 }](value T, length int) []byte {
 	return bytes
 }
 
-func authenticatorDataFlags(userPresent, userVerified, attestation, extensions bool) byte {
+func authenticatorDataFlags(userPresent, userVerified, backupEligible, backupState, attestation, extensions bool) byte {
 	// https://www.w3.org/TR/webauthn/#flags
 	flags := byte(0)
 	if userPresent {
@@ -50,6 +50,12 @@ func authenticatorDataFlags(userPresent, userVerified, attestation, extensions b
 	}
 	if userVerified {
 		flags |= 1 << 2
+	}
+	if backupEligible {
+		flags |= 1 << 3
+	}
+	if backupState {
+		flags |= 1 << 4
 	}
 	if attestation {
 		flags |= 1 << 6


### PR DESCRIPTION
## Related Issues
Fixes #31

## Description
add Backup Eligibility and Backup State flags support

before my code was:

```
authenticator := virtualwebauthn.NewAuthenticator()
```

Now if people want enable BS & BE flags the code must be modified to:

```
authenticator := virtualwebauthn.NewAuthenticatorWithOptions(virtualwebauthn.AuthenticatorOptions{
	BackupEligible: true,
	BackupState:    true,
})
```

## Must
- [ ] Tests
- [ ] Documentation (if applicable)
